### PR TITLE
Style club list items as badges

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -93,6 +93,7 @@ function render() {
   const player = data[order[i]];
   player.clubs.forEach((club) => {
     const li = document.createElement('li');
+    li.className = 'club-badge';
     li.textContent = club;
     clubsEl.appendChild(li);
   });

--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,14 @@
     p { margin: 0 0 12px; color: var(--muted); }
     ol#clubs { margin: 12px 0 0; padding-left: 1.25rem; }
     li { padding: 4px 0; }
+    .club-badge {
+      display: inline-block;
+      padding: 4px 8px;
+      border-radius: 9999px;
+      background: var(--card);
+      color: var(--fg);
+      margin: 4px;
+    }
     .controls { display: flex; gap: 10px; margin-top: 16px; }
     button { 
       appearance: none; border: 0; cursor: pointer; font-weight: 700; 


### PR DESCRIPTION
## Summary
- add a reusable `.club-badge` class in the inline styles to render club names as pill badges
- assign the new badge class to each generated club list item in the `render` function

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c997072cfc8326bb43e6f74ee6571f