### PR TITLE
Add theme toggle and light mode support

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -75,6 +75,46 @@ let data = [];
 let order = [];
 let i = 0;
 
+const themeToggle = document.getElementById('theme-toggle');
+const body = document.body;
+const THEME_STORAGE_KEY = 'player-guesser-theme';
+const DARK_THEME = 'theme-dark';
+const LIGHT_THEME = 'theme-light';
+
+function persistTheme(theme) {
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch (error) {
+    // Storage access can fail in some environments (e.g., disabled cookies).
+  }
+}
+
+function readStoredTheme() {
+  try {
+    return window.localStorage.getItem(THEME_STORAGE_KEY);
+  } catch (error) {
+    return null;
+  }
+}
+
+function updateToggleControl(theme) {
+  if (!themeToggle) return;
+  const isLight = theme === LIGHT_THEME;
+  const targetThemeLabel = isLight ? 'dark' : 'light';
+  const label = `Switch to ${targetThemeLabel} theme`;
+  themeToggle.textContent = label;
+  themeToggle.setAttribute('aria-label', label);
+  themeToggle.setAttribute('aria-pressed', String(isLight));
+}
+
+function applyTheme(theme) {
+  const nextTheme = theme === LIGHT_THEME ? LIGHT_THEME : DARK_THEME;
+  body.classList.remove(LIGHT_THEME, DARK_THEME);
+  body.classList.add(nextTheme);
+  updateToggleControl(nextTheme);
+  persistTheme(nextTheme);
+}
+
 function shuffle(n) {
   const a = Array.from({length: n}, (_, k) => k);
   for (let j = n - 1; j > 0; j--) {
@@ -110,6 +150,19 @@ document.getElementById('next').addEventListener('click', () => {
   render();
   window.scrollTo({ top: 0, behavior: 'smooth' });
 });
+
+if (themeToggle) {
+  const stored = readStoredTheme();
+  const initialTheme = stored === LIGHT_THEME || stored === DARK_THEME
+    ? stored
+    : (body.classList.contains(LIGHT_THEME) ? LIGHT_THEME : DARK_THEME);
+  applyTheme(initialTheme);
+
+  themeToggle.addEventListener('click', () => {
+    const nextTheme = body.classList.contains(DARK_THEME) ? LIGHT_THEME : DARK_THEME;
+    applyTheme(nextTheme);
+  });
+}
 
 loadPlayers().then((players) => {
   data = players;

--- a/public/index.html
+++ b/public/index.html
@@ -6,26 +6,68 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'">
   <title>Player Guesser</title>
   <style>
-    :root { --bg:#0b0f1a; --fg:#e5e7eb; --muted:#9ca3af; --card:#111827; --accent:#3b82f6; }
+    :root {
+      --accent: #3b82f6;
+      --accent-secondary: #6366f1;
+      --button-primary-fg: #ffffff;
+      --button-secondary-fg: #ffffff;
+      --bg-dark: #0b0f1a;
+      --fg-dark: #e5e7eb;
+      --muted-dark: #9ca3af;
+      --card-dark: #111827;
+      --container-dark: linear-gradient(180deg, #0f172a 0%, #0b1222 100%);
+      --shadow-dark: 0 18px 50px rgba(0, 0, 0, 0.35);
+      --bg-light: #f4f7fb;
+      --fg-light: #0f172a;
+      --muted-light: #4b5563;
+      --card-light: #ffffff;
+      --container-light: linear-gradient(180deg, #ffffff 0%, #e2e8f0 100%);
+      --shadow-light: 0 16px 32px rgba(15, 23, 42, 0.12);
+    }
     * { box-sizing: border-box; }
     html, body { height: 100%; }
     body {
       margin: 0;
       font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
-      background: var(--bg);
+      background-color: var(--bg);
       color: var(--fg);
       display: grid;
       place-items: center;
+      transition: background-color .3s ease, color .3s ease;
+    }
+    body.theme-dark {
+      --bg: var(--bg-dark);
+      --fg: var(--fg-dark);
+      --muted: var(--muted-dark);
+      --card: var(--card-dark);
+      --container-bg: var(--container-dark);
+      --container-shadow: var(--shadow-dark);
+    }
+    body.theme-light {
+      --bg: var(--bg-light);
+      --fg: var(--fg-light);
+      --muted: var(--muted-light);
+      --card: var(--card-light);
+      --container-bg: var(--container-light);
+      --container-shadow: var(--shadow-light);
     }
     .container {
       width: 100%;
       max-width: 680px;
       padding: 24px;
-      background: linear-gradient(180deg, #0f172a 0%, #0b1222 100%);
+      background: var(--container-bg);
       border-radius: 18px;
-      box-shadow: 0 18px 50px rgba(0,0,0,.35);
+      box-shadow: var(--container-shadow);
     }
-    h1 { font-size: 1.25rem; margin: 0 0 10px; letter-spacing: .3px; }
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 16px;
+    }
+    h1 { font-size: 1.25rem; margin: 0; letter-spacing: .3px; }
     p { margin: 0 0 12px; color: var(--muted); }
     ol#clubs {
       margin: 12px 0 0;
@@ -43,21 +85,33 @@
       margin: 4px;
     }
     .controls { display: flex; gap: 10px; margin-top: 16px; }
-    button { 
-      appearance: none; border: 0; cursor: pointer; font-weight: 700; 
-      padding: 12px 16px; border-radius: 12px; 
-      background: var(--accent); color: white; 
+    button {
+      appearance: none; border: 0; cursor: pointer; font-weight: 700;
+      padding: 12px 16px; border-radius: 12px;
+      background: var(--accent); color: var(--button-primary-fg);
       transition: transform .06s ease;
     }
     button:active { transform: translateY(1px); }
-    button.secondary { background: #374151; }
+    button.secondary { background: var(--accent-secondary); color: var(--button-secondary-fg); }
+    .theme-toggle {
+      padding: 10px 14px;
+      background: var(--card);
+      color: var(--fg);
+      border: 1px solid rgba(15, 23, 42, 0.12);
+      transition: background-color .3s ease, color .3s ease, border-color .3s ease, transform .06s ease;
+      flex-shrink: 0;
+    }
+    body.theme-dark .theme-toggle { border-color: rgba(255, 255, 255, 0.12); }
     #answer { display: none; font-weight: 800; margin-top: 12px; font-size: 1.1rem; }
     .footer { margin-top: 16px; font-size: .9rem; color: var(--muted); }
   </style>
 </head>
-<body>
+<body class="theme-dark">
   <main class="container" role="main">
-    <h1>Guess the player from their clubs</h1>
+    <div class="header">
+      <h1>Guess the player from their clubs</h1>
+      <button id="theme-toggle" type="button" class="theme-toggle" aria-label="Switch to light theme">Switch to light theme</button>
+    </div>
     <p>Say your guess out loud. Then reveal. (Preview test)</p>
 
     <ol id="clubs" aria-live="polite"></ol>


### PR DESCRIPTION
## Summary
- introduce shared design tokens for dark and light themes
- add a theme toggle button that persists the user preference
- apply light theme colors for the layout, badges, and controls

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c998cf7e988326b1284347eee0c6f8